### PR TITLE
Fix: Resolve channel installation failure using 'current_release' hash lookup

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -20,17 +20,39 @@ install() {
     versionListUrl="${FLUTTER_STORAGE_BASE_URL}/flutter_infra_release/releases/releases_linux.json"
   fi
   
+  local releasesJson="$(curl -sL "${versionListUrl}")"
+
+  local installChannel=""
+  if [[ "${ASDF_INSTALL_VERSION}" =~ ^(stable|beta|dev)$ ]]; then
+    installChannel="${BASH_REMATCH[1]}"
+  fi
+
   local escapedInstallVersion=$(echo $ASDF_INSTALL_VERSION | sed 's/\./\\\./g;s/\+/\\\+/g')
-  local jsonResponse=$(curl -sL "${versionListUrl}" | "${JQ_BIN}" --arg VERSION "${escapedInstallVersion}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION))')
+
+  local jsonResponse=""
+  if [ -n "${installChannel}" ]; then
+    local currentHash=$(echo "${releasesJson}" | "${JQ_BIN}" -r --arg CHANNEL "${installChannel}" '.current_release[$CHANNEL]')
+    if [ -n "${currentHash}" ] && [ "${currentHash}" != "null" ]; then
+      jsonResponse=$(echo "${releasesJson}" | "${JQ_BIN}" --arg HASH "${currentHash}" '.releases[] | select(.hash == $HASH)')
+    fi
+  fi
+
+  if [ -z "${jsonResponse}" ]; then
+    jsonResponse=$(echo "${releasesJson}" | "${JQ_BIN}" --arg VERSION "${escapedInstallVersion}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION))')
+  fi
+
   local jsonResponseLength=$(echo "${jsonResponse}" | "${JQ_BIN}" -s 'length')
-  local filePath=$(echo "${jsonResponse}" | "${JQ_BIN}" -r '.archive')
+  local filePath=$(echo "${jsonResponse}" | "${JQ_BIN}" -r '.archive' | head -n 1)
   if [ "$(uname -s)" == "Darwin" ] && [ ${jsonResponseLength} -gt 1 ]; then
     local arch="x64"
     if [ "$(uname -m)" == "arm64" ]; then
       arch="arm64"
     fi
 
-    channel=$(echo "$ASDF_INSTALL_VERSION" | grep -oE '(stable|beta|dev)$' || echo "stable")
+    local channel="${installChannel}"
+    if [ -z "${channel}" ]; then
+      channel=$(echo "$ASDF_INSTALL_VERSION" | grep -oE '(stable|beta|dev)$' || echo "stable")
+    fi
     filePath=$(echo "${jsonResponse}" | "${JQ_BIN}" -r --arg ARCH "${arch}" --arg CHANNEL "${channel}" \
       '. | select(.dart_sdk_arch == $ARCH and .channel == $CHANNEL) | .archive' | head -n 1 )
   fi


### PR DESCRIPTION
## Problem
Currently, installing named channels (e.g., `beta`, `dev`) fails when the version string does not align with the regex matching logic. This is particularly noticeable with recent beta versions (e.g., `3.x.x-pre-beta`), where the script fails to resolve the correct download URL.

## Solution
I have updated `bin/install` to correctly parse the Flutter releases JSON using the `current_release` field.

**Key changes:**
1. **Use `current_release` hash:** Instead of relying solely on regex matching against the version string, the script now looks up the hash provided in `.current_release[channel]` to identify the exact release object. This is the official and most reliable way to determine the latest version for a channel.
2. **Fallback logic:** If the hash lookup fails (or for specific version installations), it falls back to the original regex matching.
3. **Safety for multiple matches:** Added `head -n 1` to the default `filePath` extraction (Linux/Generic) to prevent script errors if multiple versions match.
4. **Optimization:** Cached the `curl` response in a variable to avoid redundant network requests.

## Testing
Verified that `mise use flutter@beta` (and other channels) installs correctly with this patch.